### PR TITLE
Downloads the compiler binaries

### DIFF
--- a/src/bin/vessel.rs
+++ b/src/bin/vessel.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use fern::colors::ColoredLevelConfig;
 use fern::Output;
 use log::LevelFilter;
+use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -24,6 +25,8 @@ enum Command {
     /// Installs all dependencies and outputs the package flags to be passed on
     /// to the Motoko compiler tools
     Sources,
+    /// Installs the compiler binaries and outputs a path to them
+    Bin,
     /// Verifies that every package in the package set builds successfully
     Verify {
         /// Path to the `moc` binary
@@ -69,6 +72,13 @@ fn main() -> Result<()> {
             let _ = vessel.install_packages()?;
             Ok(())
         }
+        Command::Bin => {
+            let vessel = vessel::Vessel::new(&opts.package_set)?;
+            let path = vessel.install_compiler()?;
+            print!("{}", path.display().to_string());
+            std::io::stdout().flush()?;
+            Ok(())
+        }
         Command::Sources => {
             let vessel = vessel::Vessel::new(&opts.package_set)?;
             let sources = vessel
@@ -78,6 +88,7 @@ fn main() -> Result<()> {
                 .collect::<Vec<_>>()
                 .join(" ");
             print!("{}", sources);
+            std::io::stdout().flush()?;
             Ok(())
         }
         Command::Verify {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,10 @@ impl Vessel {
     /// Downloads the compiler binaries at the version specified in the manifest
     /// and returns the path to them.
     pub fn install_compiler(&self) -> Result<PathBuf> {
-        let version = self.manifest.compiler.as_ref().ok_or(anyhow::anyhow!(
-            "No compiler version was specified in vessel.dhall"
-        ))?;
+        let version =
+            self.manifest.compiler.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("No compiler version was specified in vessel.dhall")
+            })?;
         download_compiler(version)
     }
 
@@ -156,11 +157,11 @@ impl Vessel {
     }
 }
 
-pub fn download_compiler(version: &String) -> Result<PathBuf> {
+pub fn download_compiler(version: &str) -> Result<PathBuf> {
     let bin = Path::new(".vessel").join(".bin");
     let dest = bin.join(&version);
     if dest.exists() {
-        return Ok(dest.to_path_buf());
+        return Ok(dest);
     }
 
     let tmp = Path::new(".vessel").join(".tmp");
@@ -189,7 +190,9 @@ pub fn download_compiler(version: &String) -> Result<PathBuf> {
             "Failed to download Motoko binaries for version {}, with \"{}\"\n\nDetails: {}",
             version,
             response.status(),
-            response.text().unwrap_or("No more details".to_string())
+            response
+                .text()
+                .unwrap_or_else(|_| "No more details".to_string())
         ));
     }
 
@@ -203,7 +206,7 @@ pub fn download_compiler(version: &String) -> Result<PathBuf> {
     }
     fs::rename(tmp_dir, &dest)?;
 
-    Ok(dest.to_path_buf())
+    Ok(dest)
 }
 
 /// Downloads a package either as a tar-ball from Github or clones it as a repo
@@ -258,7 +261,7 @@ fn download_tar_ball(tmp: &Path, dest: &Path, repo: &str, version: &str) -> Resu
             repo,
             version,
             response.status(),
-            response.text().unwrap_or("No more details".to_string())
+            response.text().unwrap_or_else(|_| "No more details".to_string())
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::{self, Context, Result};
 use flate2::read::GzDecoder;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
+use std::cfg;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
@@ -68,6 +69,62 @@ impl Vessel {
         info!("Installation complete.");
 
         Ok(paths)
+    }
+
+    /// Downloads the compiler binaries at the version specified in the manifest
+    /// and returns the path to them.
+    pub fn install_compiler(&self) -> Result<PathBuf> {
+        let version = self.manifest.compiler.clone().ok_or(anyhow::anyhow!(
+            "No compiler version was specified in vessel.dhall"
+        ))?;
+
+        let bin = Path::new(".vessel").join(".bin");
+        let dest = bin.join(&version);
+        if dest.exists() {
+            return Ok(dest.to_path_buf());
+        }
+
+        let tmp = Path::new(".vessel").join(".tmp");
+        if !tmp.exists() {
+            fs::create_dir_all(&tmp)?
+        }
+
+        let os = if cfg!(target_os = "linux") {
+            "x86_64-linux"
+        } else if cfg!(target_os = "macos") {
+            "x86_64-darwin"
+        } else {
+            return Err(anyhow::anyhow!(
+                "Installing the compiler is only supported on Linux or MacOS for now"
+            ));
+        };
+
+        let target = format!(
+            "https://download.dfinity.systems/motoko/{}/{}/motoko-{}.tar.gz",
+            version, os, version
+        );
+        let response = reqwest::blocking::get(&target)?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to download binaries for version {}, with \"{}\"\n\nDetails: {}",
+                version,
+                response.status(),
+                response.text().unwrap_or("No more details".to_string())
+            ));
+        }
+
+        // We unpack into a temporary directory and rename it in one go once
+        // the full unpacking was successful
+        let tmp_dir: TempDir = tempfile::tempdir_in(tmp)?;
+        Archive::new(GzDecoder::new(response)).unpack(tmp_dir.path())?;
+
+        if !bin.exists() {
+            fs::create_dir_all(&bin)?
+        }
+        fs::rename(tmp_dir, &dest)?;
+
+        Ok(dest.to_path_buf())
     }
 
     /// Verifies that every source file inside the given package compiles in the current package set
@@ -192,6 +249,16 @@ fn download_tar_ball(tmp: &Path, dest: &Path, repo: &str, version: &str) -> Resu
     );
     let response = reqwest::blocking::get(&target)?;
 
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Failed to download tarball for repo \"{}\" at version \"{}\", with \"{}\"\n\nDetails: {}",
+            repo,
+            version,
+            response.status(),
+            response.text().unwrap_or("No more details".to_string())
+        ));
+    }
+
     // We unpack into a temporary directory and rename it in one go once
     // the full unpacking was successful
     let tmp_dir: TempDir = tempfile::tempdir_in(tmp)?;
@@ -263,7 +330,10 @@ pub fn init() -> Result<()> {
     }
     let mut manifest = fs::File::create("vessel.dhall")?;
     manifest.write_all(
-        br#"{ dependencies = [ "base", "matchers" ] }
+        br#"{
+  dependencies = [ "base", "matchers" ],
+  compiler = Some "0.4.2"
+}
 "#,
     )?;
     let mut manifest = fs::File::create("package-set.dhall")?;
@@ -345,6 +415,7 @@ pub struct PackageSet(pub HashMap<Name, Package>);
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize, serde_dhall::StaticType)]
 pub struct Manifest {
+    pub compiler: Option<String>,
     pub dependencies: Vec<Name>,
 }
 


### PR DESCRIPTION
Breaking change, the user is now expected to either specify `compiler = Some "x.x.x"` or `compiler = None Text` in their `vessel.dhall` file. Package sets can now also be verified against a compiler version of the users choosing.

This can be used to access `moc` or `mo-doc` like:
`$(vessel bin)/moc` or `$(vessel bin)/mo-doc`

@matthewhammer Could I get you to take a quick look at the code?