### PR TITLE
Defaults to no compiler on initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub fn init() -> Result<()> {
     manifest.write_all(
         br#"{
   dependencies = [ "base", "matchers" ],
-  compiler = Some "0.4.2"
+  compiler = None Text
 }
 "#,
     )?;


### PR DESCRIPTION
This setting is only relevant for projects that don't use `dfx`, which means basically none at this point. So adding it here just causes confusion.