### PR TITLE
Clean up Nix configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,47 +1,29 @@
-{
-  system ? builtins.currentSystem,
-}:
-
-let nixpkgs = import ./nix { inherit system; }; in
-let stdenv = nixpkgs.stdenv; in
-let subpath = p: import ./nix/gitSource.nix p; in
-
-let vessel = nixpkgs.rustPlatform.buildRustPackage rec {
-  pname = "vessel";
-  version = "1.0.0";
-  buildInputs = [
-    nixpkgs.openssl
-    nixpkgs.openssl.dev
-  ];
-  nativeBuildInputs = [
-    nixpkgs.pkg-config
-  ];
-
-  src = subpath ./.;
-
-  cargoSha256 = "0kykwbqhh4zm4si0ibr89m3vas7ldpg90r8kjfv0qn5mr22zw48c";
-  verifyCargoDeps = true;
-}; in
-
-rec {
-  inherit vessel;
-
-  all-systems-go = nixpkgs.releaseTools.aggregate {
-    name = "all-systems-go";
-    constituents = [
-      vessel
-    ];
+{ system ? builtins.currentSystem, nixpkgs ? import ./nix { inherit system; } }:
+with nixpkgs;
+let
+  subpath = import ./nix/gitSource.nix;
+  noNixFile = name: type:
+    let baseName = builtins.baseNameOf (builtins.toString name);
+    in !(lib.hasSuffix ".nix" name);
+  vessel = rustPlatform.buildRustPackage rec {
+    pname = "vessel";
+    version = "1.0.0";
+    buildInputs = [ openssl openssl.dev ];
+    nativeBuildInputs = [ pkg-config ];
+    src = lib.sources.cleanSourceWith {
+      filter = noNixFile;
+      src = subpath ./.;
+    };
+    cargoSha256 = "07rz0gm6yqxmi34dzgia31h1kvk70xa3rb7h7ygl6pylx71grwbj";
+    verifyCargoDeps = true;
   };
-
+in rec {
+  inherit vessel;
   # include shell in default.nix so that the nix cache will have pre-built versions
   # of all the dependencies that are only depended on by nix-shell.
   shell =
-    let extra-pkgs = [
-          nixpkgs.easy-dhall.dhall-simple
-          nixpkgs.easy-dhall.dhall-lsp-simple
-    ]; in
-
-    vessel.overrideAttrs (old: {
-      nativeBuildInputs = (old.nativeBuildInputs or []) ++ extra-pkgs ;
+    let extra-pkgs = [ easy-dhall.dhall-simple easy-dhall.dhall-lsp-simple ];
+    in vessel.overrideAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ extra-pkgs;
     });
 }


### PR DESCRIPTION
- Update cargo sha256.
- Skip nix files in package source for cargo build.
- Remove all-systems-go, which builds vessel twice. It is probably not used anyway.
- Run nixfmt over default.nix.

Closes #16 