### PR TITLE
Add nix-build to CI

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,13 @@
+name: "Nix Build"
+on:
+  pull_request:
+  push:
+jobs:
+  all-targets:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build


### PR DESCRIPTION
This adds nix-build to CI to catch any nix-build failures.